### PR TITLE
fix extension update issue as part of PostgreSQL 16 upgrade initiative

### DIFF
--- a/sql/first_last_agg--0.1.4--0.1.5.sql
+++ b/sql/first_last_agg--0.1.4--0.1.5.sql
@@ -9,16 +9,14 @@ BEGIN
     EXECUTE $E$ ALTER FUNCTION last_sfunc(anyelement, anyelement) PARALLEL SAFE   $E$;
     EXECUTE $E$ ALTER FUNCTION first_sfunc(anyelement, anyelement) PARALLEL SAFE   $E$;
 
-    EXECUTE $E$ DROP AGGREGATE IF EXISTS first(anyelement) $E$;
-    EXECUTE $E$ CREATE AGGREGATE first(anyelement) (
+    EXECUTE $E$ CREATE OR REPLACE AGGREGATE first(anyelement) (
         SFUNC = first_sfunc,
         STYPE = anyelement,
         COMBINEFUNC = first_sfunc,
         parallel = SAFE
     ); $E$;
 
-    EXECUTE $E$ DROP AGGREGATE IF EXISTS last(anyelement) $E$;
-    EXECUTE $E$ CREATE AGGREGATE last(anyelement) (
+    EXECUTE $E$ CREATE OR REPLACE AGGREGATE last(anyelement) (
         SFUNC = last_sfunc,
         STYPE = anyelement,
         COMBINEFUNC = last_sfunc,

--- a/sql/first_last_agg--0.1.5--0.1.4.sql
+++ b/sql/first_last_agg--0.1.5--0.1.4.sql
@@ -9,14 +9,12 @@ BEGIN
     EXECUTE $E$ ALTER FUNCTION last_sfunc(anyelement, anyelement) PARALLEL UNSAFE   $E$;
     EXECUTE $E$ ALTER FUNCTION first_sfunc(anyelement, anyelement) PARALLEL UNSAFE   $E$;
 
-    EXECUTE $E$ DROP AGGREGATE IF EXISTS first(anyelement) $E$;
-    EXECUTE $E$ CREATE AGGREGATE first(anyelement) (
+    EXECUTE $E$ CREATE OR REPLACE AGGREGATE first(anyelement) (
         SFUNC = first_sfunc,
         STYPE = anyelement
     ); $E$;
 
-    EXECUTE $E$ DROP AGGREGATE IF EXISTS last(anyelement) $E$;
-    EXECUTE $E$ CREATE AGGREGATE last(anyelement) (
+    EXECUTE $E$ CREATE OR REPLACE AGGREGATE last(anyelement) (
         SFUNC = last_sfunc,
         STYPE = anyelement
     ); $E$;


### PR DESCRIPTION
When you try to update first_last_agg extension, it fails, this PR fixes it.
```
ams_pg_temp_1=# alter extension first_last_agg update ;
ERROR:  cannot drop function last(anyelement) because other objects depend on it
DETAIL:  extension ajcost depends on function last(anyelement)
extension change_tracker depends on function last(anyelement)
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
CONTEXT:  SQL statement " DROP AGGREGATE IF EXISTS last(anyelement) "
PL/pgSQL function inline_code_block line 17 at EXECUTE
ams_pg_temp_1=# 
```