### PR TITLE
Cut 0.1.6 with a PG10-safe migration path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ sql/first_last_agg--0.1.2.sql
 sql/first_last_agg--0.1.3.sql
 sql/first_last_agg--0.1.4.sql
 sql/first_last_agg--0.1.5.sql
+sql/first_last_agg--0.1.6.sql
+!sql/first_last_agg--0.1.4.sql
 src/first_last_agg.o
 src/first_last_agg.so

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
    "name": "first_last_agg",
    "abstract": "Provides first() and last() aggregate functions.",
-   "version": "0.1.5",
+   "version": "0.1.6",
    "maintainer" : [
       "adjustgmbh"
    ],
@@ -11,7 +11,7 @@
       "first_last_agg": {
          "file": "sql/first_last_agg.sql",
          "docfile": "doc/first_last_agg.md",
-         "version": "0.1.5",
+         "version": "0.1.6",
          "abstract": "Provides first() and last() aggregate functions."
       }
    },

--- a/first_last_agg.control
+++ b/first_last_agg.control
@@ -1,5 +1,5 @@
 # first_last_agg extension
 comment = 'first() and last() aggregate functions'
-default_version = '0.1.5'
+default_version = '0.1.6'
 module_pathname = '$libdir/first_last_agg'
 relocatable = true

--- a/sql/first_last_agg--0.1.4--0.1.6.sql
+++ b/sql/first_last_agg--0.1.4--0.1.6.sql
@@ -1,0 +1,29 @@
+/*
+ * Make aggregate functions parallel safe for supported server versions.
+ */
+DO $$
+DECLARE version_num integer;
+BEGIN
+  SELECT current_setting('server_version_num') INTO STRICT version_num;
+  IF version_num > 90600 THEN
+    EXECUTE $E$ ALTER FUNCTION last_sfunc(anyelement, anyelement) PARALLEL SAFE $E$;
+    EXECUTE $E$ ALTER FUNCTION first_sfunc(anyelement, anyelement) PARALLEL SAFE $E$;
+
+    EXECUTE $E$ DROP AGGREGATE IF EXISTS first(anyelement) $E$;
+    EXECUTE $E$ CREATE AGGREGATE first(anyelement) (
+        SFUNC = first_sfunc,
+        STYPE = anyelement,
+        COMBINEFUNC = first_sfunc,
+        PARALLEL = SAFE
+    ) $E$;
+
+    EXECUTE $E$ DROP AGGREGATE IF EXISTS last(anyelement) $E$;
+    EXECUTE $E$ CREATE AGGREGATE last(anyelement) (
+        SFUNC = last_sfunc,
+        STYPE = anyelement,
+        COMBINEFUNC = last_sfunc,
+        PARALLEL = SAFE
+    ) $E$;
+  END IF;
+END;
+$$;

--- a/sql/first_last_agg--0.1.4.sql
+++ b/sql/first_last_agg--0.1.4.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION last_sfunc(anyelement, anyelement)
+RETURNS anyelement
+AS '$libdir/first_last_agg', 'last_sfunc'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION first_sfunc(anyelement, anyelement)
+RETURNS anyelement
+AS '$libdir/first_last_agg', 'first_sfunc'
+LANGUAGE C IMMUTABLE STRICT;
+
+DROP AGGREGATE IF EXISTS first(anyelement);
+CREATE AGGREGATE first(anyelement) (
+    SFUNC = first_sfunc,
+    STYPE = anyelement
+);
+
+DROP AGGREGATE IF EXISTS last(anyelement);
+CREATE AGGREGATE last(anyelement) (
+    SFUNC = last_sfunc,
+    STYPE = anyelement
+);

--- a/sql/first_last_agg--0.1.5--0.1.6.sql
+++ b/sql/first_last_agg--0.1.5--0.1.6.sql
@@ -1,0 +1,4 @@
+/*
+ * Version 0.1.6 keeps the SQL object definitions from 0.1.5 unchanged.
+ * This release only adds a PostgreSQL 10-safe direct migration path from 0.1.4.
+ */

--- a/sql/first_last_agg--0.1.6--0.1.5.sql
+++ b/sql/first_last_agg--0.1.6--0.1.5.sql
@@ -1,0 +1,4 @@
+/*
+ * Version 0.1.6 keeps the SQL object definitions from 0.1.5 unchanged.
+ * This downgrade exists to preserve an explicit path between the tagged releases.
+ */

--- a/test/expected/migration.out
+++ b/test/expected/migration.out
@@ -1,0 +1,58 @@
+BEGIN;
+SET client_min_messages TO 'WARNING';
+CREATE EXTENSION first_last_agg VERSION '0.1.5';
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+ extversion 
+------------
+ 0.1.5
+(1 row)
+
+ALTER EXTENSION first_last_agg UPDATE TO '0.1.6';
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+ extversion 
+------------
+ 0.1.6
+(1 row)
+
+DROP EXTENSION first_last_agg;
+CREATE EXTENSION first_last_agg VERSION '0.1.4';
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+ extversion 
+------------
+ 0.1.4
+(1 row)
+
+ALTER EXTENSION first_last_agg UPDATE TO '0.1.6';
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+ extversion 
+------------
+ 0.1.6
+(1 row)
+
+CREATE TEMPORARY TABLE migration_test (
+    akey integer,
+    val1 integer,
+    val2 integer
+);
+INSERT INTO migration_test (akey, val1, val2)
+VALUES (1, 2, 1), (1, 4, 2), (1, 3, 3),
+       (2, 2, 1), (2, NULL, 2), (2, 5, 3);
+SELECT akey, first(val1 ORDER BY val2) AS first, last(val1 ORDER BY val2) AS last
+FROM migration_test
+GROUP BY akey
+ORDER BY akey;
+ akey | first | last 
+------+-------+------
+    1 |     2 |    3
+    2 |     2 |    5
+(2 rows)
+
+ROLLBACK;

--- a/test/sql/migration.sql
+++ b/test/sql/migration.sql
@@ -1,0 +1,45 @@
+BEGIN;
+SET client_min_messages TO 'WARNING';
+
+CREATE EXTENSION first_last_agg VERSION '0.1.5';
+
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+
+ALTER EXTENSION first_last_agg UPDATE TO '0.1.6';
+
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+
+DROP EXTENSION first_last_agg;
+
+CREATE EXTENSION first_last_agg VERSION '0.1.4';
+
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+
+ALTER EXTENSION first_last_agg UPDATE TO '0.1.6';
+
+SELECT extversion
+FROM pg_extension
+WHERE extname = 'first_last_agg';
+
+CREATE TEMPORARY TABLE migration_test (
+    akey integer,
+    val1 integer,
+    val2 integer
+);
+
+INSERT INTO migration_test (akey, val1, val2)
+VALUES (1, 2, 1), (1, 4, 2), (1, 3, 3),
+       (2, 2, 1), (2, NULL, 2), (2, 5, 3);
+
+SELECT akey, first(val1 ORDER BY val2) AS first, last(val1 ORDER BY val2) AS last
+FROM migration_test
+GROUP BY akey
+ORDER BY akey;
+
+ROLLBACK;


### PR DESCRIPTION
## Context
`first_last_agg` currently declares PostgreSQL 10 support, but the released `0.1.5` migration script `0.1.4 -> 0.1.5` uses `CREATE OR REPLACE AGGREGATE`, which PostgreSQL 10 does not support.

Some hosts are already on `0.1.5`, so this PR does not rewrite that released version in place. Instead it cuts `0.1.6` and adds a direct PostgreSQL 10-safe `0.1.4 -> 0.1.6` path.

## Changes
- bump `first_last_agg.control` and `META.json` to `0.1.6`
- preserve the existing `0.1.4 -> 0.1.5` and `0.1.5 -> 0.1.4` scripts unchanged
- add a tracked `sql/first_last_agg--0.1.4.sql` install script so tests and tooling can create version `0.1.4` directly without traversing later downgrade paths
- add `sql/first_last_agg--0.1.4--0.1.6.sql` with PG10-safe `DROP AGGREGATE IF EXISTS` + `CREATE AGGREGATE`
- add explicit no-op release paths:
  - `sql/first_last_agg--0.1.5--0.1.6.sql`
  - `sql/first_last_agg--0.1.6--0.1.5.sql`
- add a regression test covering:
  - create extension at `0.1.5`
  - update `0.1.5 -> 0.1.6`
  - create extension at `0.1.4`
  - direct update `0.1.4 -> 0.1.6`
- update `.gitignore` so `sql/first_last_agg--0.1.4.sql` remains tracked while generated current-version install scripts stay ignored

## Why this is safe
PostgreSQL extension update scripts may drop extension member objects; dropped members are dissociated automatically, and objects created by the update script are added back to the extension. The new `0.1.4 -> 0.1.6` path matches the install-time `DROP`/`CREATE AGGREGATE` pattern already used in `sql/first_last_agg.sql`.

The regression test intentionally avoids invoking the preserved PG10-incompatible `0.1.5 -> 0.1.4` downgrade script. That script remains unchanged because this release strategy is to add a safe forward path via `0.1.6`, not to rewrite historical `0.1.5` semantics.

## Validation
- ran `make installcheck` against a temporary local PostgreSQL 17 cluster; both regression tests passed, including the updated migration test
- confirmed the direct PG10 incompatibility from the upstream PostgreSQL 10 `CREATE AGGREGATE` docs plus a failing PG10 host repro
- checked the latest GitHub Actions failure and fixed the remaining issue by adding a direct `0.1.4` install script for the regression test path

## Risk
Low. This preserves the existing `0.1.5` release semantics and adds an explicit `0.1.6` upgrade path for both hosts already on `0.1.5` and PostgreSQL 10 hosts still on `0.1.4`.